### PR TITLE
kernel: free hdmi rx buffers on release

### DIFF
--- a/linux-rtk/drivers/media/platform/rtk_hdmirx/rtd129x/hdmirx_video_dev.c
+++ b/linux-rtk/drivers/media/platform/rtk_hdmirx/rtd129x/hdmirx_video_dev.c
@@ -408,15 +408,9 @@ static long v4l2_hdmi_do_ioctl(struct file *file, unsigned int cmd, void *arg)
 	}
 	case VIDIOC_STREAMOFF:
 	{
-		struct vb2_queue *vq;
-
 		HDMIRX_INFO(" ioctl VIDIOC_STREAMOFF");
 
 		vb2_streamoff(&dev->vb_hdmidq, dev->vb_hdmidq.type);
-
-		/* Release queue */
-		vq = &dev->vb_hdmidq;
-		vb2_queue_release(vq);
 
 		hdmi_timestamp_mode = 0;
 
@@ -536,6 +530,20 @@ long v4l2_hdmi_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
 	HDMIRX_DEBUG(" return ioctl TYPE(0x%x) NR(%u) SIZE(%u)",
 		_IOC_TYPE(cmd), _IOC_NR(cmd), _IOC_SIZE(cmd));
 	return ret;
+}
+
+int compat_fop_release(struct file *file)
+{
+	struct v4l2_hdmi_dev *dev = video_drvdata(file);
+	struct vb2_queue *vq;
+
+	HDMIRX_INFO("[%s]", __func__);
+
+	/* Release queue */
+	vq = &dev->vb_hdmidq;
+	vb2_queue_release(vq);
+
+	return vb2_fop_release(file);
 }
 
 long compat_v4l2_hdmi_ioctl(struct file *file, unsigned int cmd, unsigned long arg)

--- a/linux-rtk/drivers/media/platform/rtk_hdmirx/rtd129x/hdmirx_video_dev.h
+++ b/linux-rtk/drivers/media/platform/rtk_hdmirx/rtd129x/hdmirx_video_dev.h
@@ -17,6 +17,7 @@
 
 long v4l2_hdmi_ioctl(struct file *file, unsigned int cmd, unsigned long arg);
 long compat_v4l2_hdmi_ioctl(struct file *file, unsigned int cmd, unsigned long arg);
+int compat_fop_release(struct file *file);
 int v4l2_mipi_top_open(struct file *filp);
 
 struct compat_v4l2_plane {
@@ -57,7 +58,7 @@ struct compat_v4l2_buffer {
 static const struct v4l2_file_operations hdmi_fops = {
 	.owner			= THIS_MODULE,
 	.open			= v4l2_mipi_top_open,
-	.release		= vb2_fop_release,
+	.release		= compat_fop_release,
 	.read			= vb2_fop_read,
 	.poll			= vb2_fop_poll,
 	.unlocked_ioctl = v4l2_hdmi_ioctl, /* V4L2 ioctl handler */


### PR DESCRIPTION
hdmi rx buffers were being freed on the VIDIOC_STREAMOFF ioctl call
this prevented the video stream from being turned on and off more than once
and also resulted in memory leaks, as the buffers weren't freed if the
user-space process crashed or was killed without calling VIDIOC_STREAMOFF.